### PR TITLE
Add generic type to isHttpError

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Http Error
 
-[![version](https://img.shields.io/badge/release-0.6.0-success)](https://deno.land/x/http_error@0.6.0)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/http_error@0.6.0/mod.ts)
+[![version](https://img.shields.io/badge/release-0.7.0-success)](https://deno.land/x/http_error@0.7.0)
+[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/http_error@0.7.0/mod.ts)
 [![CI](https://github.com/udibo/http_error/workflows/CI/badge.svg)](https://github.com/udibo/http_error/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/udibo/http_error/branch/main/graph/badge.svg?token=8Q7TSUFWUY)](https://codecov.io/gh/udibo/http_error)
 [![license](https://img.shields.io/github/license/udibo/http_error)](https://github.com/udibo/http_error/blob/master/LICENSE)
@@ -30,9 +30,9 @@ imported directly from GitHub using raw content URLs.
 
 ```ts
 // Import from Deno's third party module registry
-import { HttpError, isHttpError } from "https://deno.land/x/http_error@0.6.0/mod.ts";
+import { HttpError, isHttpError } from "https://deno.land/x/http_error@0.7.0/mod.ts";
 // Import from GitHub
-import { HttpError, isHttpError } "https://raw.githubusercontent.com/udibo/http_error/0.6.0/mod.ts";
+import { HttpError, isHttpError } "https://raw.githubusercontent.com/udibo/http_error/0.7.0/mod.ts";
 ```
 
 ### Node.js
@@ -43,7 +43,7 @@ If a Node.js package has the type "module" specified in its package.json file,
 the JavaScript bundle can be imported as a `.js` file.
 
 ```js
-import { HttpError, isHttpError } from "./http_error_0.6.0.js";
+import { HttpError, isHttpError } from "./http_error_0.7.0.js";
 ```
 
 The default type for Node.js packages is "commonjs". To import the bundle into a
@@ -51,7 +51,7 @@ commonjs package, the file extension of the JavaScript bundle must be changed
 from `.js` to `.mjs`.
 
 ```js
-import { HttpError, isHttpError } from "./http_error_0.6.0.mjs";
+import { HttpError, isHttpError } from "./http_error_0.7.0.mjs";
 ```
 
 See [Node.js Documentation](https://nodejs.org/api/esm.html) for more
@@ -70,7 +70,7 @@ modules must have the type attribute set to "module".
 
 ```js
 // main.js
-import { HttpError, isHttpError } from "./http_error_0.6.0.js";
+import { HttpError, isHttpError } from "./http_error_0.7.0.js";
 ```
 
 You can also embed a module script directly into an HTML file by placing the
@@ -78,7 +78,7 @@ JavaScript code within the body of the script tag.
 
 ```html
 <script type="module">
-  import { HttpError, isHttpError } from "./http_error_0.6.0.js";
+  import { HttpError, isHttpError } from "./http_error_0.7.0.js";
 </script>
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -186,7 +186,9 @@ export class HttpError<
 }
 
 /** Checks if the value as an HttpError. */
-export function isHttpError(value: unknown): value is HttpError {
+export function isHttpError<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(value: unknown): value is HttpError<T> {
   return !!value && typeof value === "object" &&
     (value instanceof HttpError ||
       (value instanceof Error &&


### PR DESCRIPTION
This gives the ability to specify the type of HttpError that is expected. It won't validate the options but it will assert the correct type.