### PR TITLE
Remove module doc from main entrypoint

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@udibo/http-error",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "exports": {
     ".": "./mod.ts"
   },

--- a/mod.ts
+++ b/mod.ts
@@ -1,8 +1,3 @@
-/**
- * Utilities for creating and working with Http Errors.
- *
- * @module
- */
 import { STATUS_CODE, STATUS_TEXT, type StatusCode } from "@std/http/status";
 
 /** Options for initializing an HttpError. */


### PR DESCRIPTION
I believe this will make it so that JSR will show the README.md file instead of the module doc on the overview page.