### PR TITLE
Fix isHttpErrorLike type

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@udibo/http-error",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "exports": {
     ".": "./mod.ts"
   },

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -11,6 +11,7 @@ import {
   createHttpErrorClass,
   HttpError,
   type HttpErrorOptions,
+  isHttpErrorLike,
 } from "./mod.ts";
 
 const httpErrorTests = describe("HttpError");
@@ -1216,3 +1217,17 @@ it(
     assertEquals(secretBody, secretJson);
   },
 );
+
+it("isHttpErrorLike", () => {
+  const httpError = new HttpError(400, "Bad Request");
+  assertEquals(isHttpErrorLike(httpError), true);
+  assertEquals(isHttpErrorLike(new Error("Bad Request")), false);
+  assertEquals(isHttpErrorLike({ status: 400, message: "Bad Request" }), false);
+  const error = new Error("Bad Request");
+  assertEquals(isHttpErrorLike(error), false);
+  (error as HttpError).status = 400;
+  assertEquals(isHttpErrorLike(error), true);
+  if (isHttpErrorLike(error)) {
+    assertEquals(error.status, 400);
+  }
+});

--- a/mod.ts
+++ b/mod.ts
@@ -677,7 +677,9 @@ export class HttpError<
  */
 export function isHttpErrorLike<
   Extensions extends object = Record<string, unknown>,
->(value: unknown): value is HttpError<Extensions> | Error {
+>(
+  value: unknown,
+): value is HttpError<Extensions> | (Error & { status: number }) {
   return typeof value === "object" && value !== null &&
     (value instanceof HttpError ||
       (value instanceof Error &&


### PR DESCRIPTION
Accessing status after calling isHttpErrorLike didn't work because it could still be a regular Error. Updated type assertion so that Error has status. Added test case to show accessing status after isHttpErrorLike works.